### PR TITLE
Fix behaviour of psq_assert_set.

### DIFF
--- a/PolysquareToolingUtil.cmake
+++ b/PolysquareToolingUtil.cmake
@@ -102,11 +102,12 @@ endfunction (psq_add_switch)
 
 function (psq_assert_set VARIABLE)
 
-    if (NOT VARIABLE)
+    if (NOT ${VARIABLE})
 
-        message (FATAL_ERROR "${ARGN}")
+        string (REPLACE ";" "" MSG "${ARGN}")
+        message (FATAL_ERROR "${MSG}")
 
-    endif (NOT VARIABLE)
+    endif (NOT ${VARIABLE})
 
 endfunction (psq_assert_set)
 


### PR DESCRIPTION
Check for ${VARIABLE} instead of VARIABLE (the former will merely check if the
variable named VARIABLE instead of the actual variable name is set).

Also strip semicolons from error message.
