### PR TITLE
Add a new DEPENDS option to ensure tool runs after DEPENDS.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,8 @@ add_cmake_test (SpecialCompilationDBUseCXXLanguageOptForCPPHeader)
 
 add_cmake_build_test (RunToolOnSource
                       RunToolOnSourceVerify)
+add_cmake_build_test (RunToolOnSourceAfterDepends
+                      RunToolOnSourceAfterDependsVerify)
 add_cmake_build_test (RunToolOnSourceGeneratesStampfile
                       RunToolOnSourceGeneratesStampfileVerify)
 add_cmake_build_test (RunToolOnSourceGeneratesStampfileWithSpaces

--- a/test/RunToolOnSourceAfterDepends.cmake
+++ b/test/RunToolOnSourceAfterDepends.cmake
@@ -1,0 +1,19 @@
+# /tests/RunToolOnSourceAfterDepends.cmake
+# Adds a custom target with a source and calls psq_run_tool_on_source
+# on it (the "tool" in this case being ${CMAKE_COMMAND} -E echo ${SOURCE}) and
+# add a custom target "custom_dependency" not put on ALL to DEPENDS
+#
+# See LICENCE.md for Copyright information
+
+include (CMakeUnit)
+include (PolysquareToolingUtil)
+
+set (SOURCE_FILE ${CMAKE_CURRENT_BINARY_DIR}/Source.cpp)
+file (WRITE ${SOURCE_FILE} "")
+
+add_custom_target (custom_dependency
+                   COMMAND cmake -E echo "ran custom_dependency")
+add_custom_target (target ALL SOURCES ${SOURCE_FILE})
+psq_run_tool_on_source (target ${SOURCE_FILE} "Tool"
+                        COMMAND ${CMAKE_COMMAND} -E echo ${SOURCE_FILE}
+                        DEPENDS custom_dependency)

--- a/test/RunToolOnSourceAfterDependsVerify.cmake
+++ b/test/RunToolOnSourceAfterDependsVerify.cmake
@@ -1,0 +1,11 @@
+# /tests/RunToolOnSourceAfterDependsVerify.cmake
+# Verifies that our "custom_dependency" target got built. If it wasn't built
+# then it was never run.
+#
+# See LICENCE.md for Copyright information
+
+include (CMakeUnit)
+
+set (BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/BUILD.output)
+
+assert_file_has_line_matching (${BUILD_OUTPUT} "^.*custom_dependency*$")


### PR DESCRIPTION
Also implicitly add all generated sources to it. This ensures that for parallel
builds, all the pre-existing generated sources and DEPENDS will be run
before running the checker.
